### PR TITLE
Avoid percentage like 55.00000000000001%

### DIFF
--- a/src/ProgressBar.vue
+++ b/src/ProgressBar.vue
@@ -25,7 +25,7 @@ export default {
 
   computed: {
     percentage () {
-      return this.value / this.max * 100
+      return Math.floor(this.value / this.max * 100)
     }
   }
 


### PR DESCRIPTION
This is what I'm experiencing with actual component:
![image](https://cloud.githubusercontent.com/assets/1532657/23530865/ed4eefe8-ffa3-11e6-8f5e-0326492ef551.png)
